### PR TITLE
Fix Win64's popup-close crash

### DIFF
--- a/src/ActivityWin.cpp
+++ b/src/ActivityWin.cpp
@@ -274,7 +274,7 @@ LRESULT APIENTRY ActivityWin::wndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
     {
         case WM_CREATE:
             aw = (ActivityWin*)((LPCREATESTRUCT)lParam)->lpCreateParams;
-            SetWindowLongPtr(hWnd, GWLP_USERDATA, PtrToUlong(aw));
+            SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(aw));
         return 0;
 
         case WM_SETFOCUS:


### PR DESCRIPTION
[Problem] Popup-closing makes npp crash after DB operation only in 64bit
[Reason] The address is truncated at SetWindowLongPtr by PtrToUlong
[Solution] Use a normal casting instead of PtrToUlong. PtrToUlong can just turn off warning while it truncates a value.