### PR TITLE
Fix GetFilename() to return the filename without first letter cut-off

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -774,10 +774,7 @@ const TCHAR* CPath::GetFilename() const
 
     for (; len > 0; --len)
         if (_buf[len - 1] == _T('\\') || _buf[len - 1] == _T('/'))
-        {
-            ++len;
             break;
-        }
 
     return &_buf[len];
 }


### PR DESCRIPTION
Fix #43